### PR TITLE
feat(ctv): add IndexTTS API integration

### DIFF
--- a/ctv/.env
+++ b/ctv/.env
@@ -1,7 +1,7 @@
 # ====== 基本开关（可选，不填则用命令行参数或脚本默认）======
 # OCR 默认供应商：tencent / baidu / rapidocr / tesseract / http
 OCR_VENDOR=http
-# TTS 默认供应商：iflytek / edge / azure / elevenlabs / gtts / pyttsx3 / http / chatts
+# TTS 默认供应商：iflytek / edge / azure / elevenlabs / gtts / pyttsx3 / http / chatts / indextts
 TTS_VENDOR=chatts
 
 # ====== HTTP OCR / TTS（示例对应：--ocr-engine http --tts-engine http --voice-lang ZH --voice-name ZH）======
@@ -35,6 +35,47 @@ CHATTTS_NORMALIZE=true
 CHATTTS_HOMOPHONE=false
 # 请求超时时间秒（例：--chatts-timeout）
 CHATTTS_TIMEOUT=120.0
+
+# ====== IndexTTS API（可选，对应 --tts-engine indextts）======
+INDEXTTS_API_URL=http://127.0.0.1:8000/tts
+INDEXTTS_PROMPT_WAV=assets/prompt.wav
+# 默认情感（对应下方 *_NEUTRAL 等变量，可设为 neutral / happy / sad / angry 等自定义关键字）
+INDEXTTS_EMOTION=neutral
+# 参考音频与情感音频，可按需增删情感关键字（示例：NEUTRAL/HAPPY/SAD/ANGRY）
+INDEXTTS_EMO_WAV_NEUTRAL=
+INDEXTTS_EMO_TEXT_NEUTRAL=
+INDEXTTS_EMO_VECTOR_JSON_NEUTRAL=
+INDEXTTS_USE_EMO_TEXT_NEUTRAL=false
+INDEXTTS_EMO_ALPHA_NEUTRAL=1.0
+
+INDEXTTS_EMO_WAV_HAPPY=
+INDEXTTS_EMO_TEXT_HAPPY=
+INDEXTTS_EMO_VECTOR_JSON_HAPPY=
+INDEXTTS_USE_EMO_TEXT_HAPPY=false
+INDEXTTS_EMO_ALPHA_HAPPY=1.0
+
+INDEXTTS_EMO_WAV_SAD=
+INDEXTTS_EMO_TEXT_SAD=
+INDEXTTS_EMO_VECTOR_JSON_SAD=
+INDEXTTS_USE_EMO_TEXT_SAD=false
+INDEXTTS_EMO_ALPHA_SAD=1.0
+
+INDEXTTS_EMO_WAV_ANGRY=
+INDEXTTS_EMO_TEXT_ANGRY=
+INDEXTTS_EMO_VECTOR_JSON_ANGRY=
+INDEXTTS_USE_EMO_TEXT_ANGRY=false
+INDEXTTS_EMO_ALPHA_ANGRY=1.0
+
+# 通用推理控制参数（若需按情感覆盖，可增加 INDEXTTS_TEMPERATURE_HAPPY 等变量）
+INDEXTTS_USE_RANDOM=false
+INDEXTTS_INTERVAL_SILENCE=200
+INDEXTTS_MAX_TEXT_TOKENS=120
+INDEXTTS_TEMPERATURE=0.8
+INDEXTTS_TOP_P=0.8
+INDEXTTS_TOP_K=30
+INDEXTTS_REPETITION_PENALTY=10.0
+INDEXTTS_MAX_MEL_TOKENS=1500
+INDEXTTS_TIMEOUT=180.0
 
 # ====== 腾讯 OCR ======
 TENCENT_SECRET_ID=


### PR DESCRIPTION
## Summary
- integrate an IndexTTS REST client into the CTV workflow, including emotion-specific controls and request handling
- expose IndexTTS configuration via .env with defaults for prompt audio, emotion presets, and inference parameters
- extend CLI/environment parsing to resolve IndexTTS assets and validate configuration before processing

## Testing
- python -m py_compile index-tts/ctv/ctv.py

------
https://chatgpt.com/codex/tasks/task_b_68cbc5c83ca0832681c98e37b374eb06