### PR TITLE
Enable PDF input for cvt pipeline

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -46,6 +46,7 @@ dependencies = [
   "numpy==1.26.2",
   "omegaconf>=2.3.0",
   "opencv-python==4.9.0.80",
+  "pypdfium2>=4.30.0",
   "pandas==2.3.2",
   "safetensors==0.5.2",
   "sentencepiece>=0.2.1",


### PR DESCRIPTION
## Summary
- render PDF inputs to temporary images so the cvt pipeline can process multipage documents
- add input preparation helper with clear errors and cleanup logic when using PDFs
- declare the new pypdfium2 dependency required for PDF rendering

## Testing
- python -m compileall ctv/ctv.py


------
https://chatgpt.com/codex/tasks/task_b_68cca9c84304832698aa4dab87bc5ad9