### PR TITLE
Enable GPT KV cache on CPU inference

### DIFF
--- a/indextts/infer.py
+++ b/indextts/infer.py
@@ -97,7 +97,9 @@ class IndexTTS:
 
             self.gpt.post_init_gpt2_config(use_deepspeed=use_deepspeed, kv_cache=True, half=True)
         else:
-            self.gpt.post_init_gpt2_config(use_deepspeed=False, kv_cache=False, half=False)
+            # CPU推理时启用KV缓存可以避免重复计算历史token，对长文本生成性能提升明显。
+            enable_kv_cache = self.device == "cpu"
+            self.gpt.post_init_gpt2_config(use_deepspeed=False, kv_cache=enable_kv_cache, half=False)
 
         if self.use_cuda_kernel:
             # preload the CUDA kernel for BigVGAN


### PR DESCRIPTION
## Summary
- enable the GPT inference KV cache when running purely on the CPU to avoid recomputing the full context on every decoding step
- document the motivation inline so future maintainers understand why the cache is activated for CPU runs

## Testing
- pytest tests/padding_test.py *(fails: ModuleNotFoundError: No module named 'torch')*

------
https://chatgpt.com/codex/tasks/task_b_68d4f62a09b88326b404b42276897bff