### PR TITLE
Enable multi-GPU inference in API server

### DIFF
--- a/api_server.py
+++ b/api_server.py
@@ -5,8 +5,13 @@ import json
 import shutil
 import tempfile
 from pathlib import Path
-from typing import Optional
 
+import asyncio
+from collections import deque
+from contextlib import asynccontextmanager
+from typing import List, Optional
+
+import torch
 from fastapi import FastAPI, File, Form, UploadFile
 from fastapi.responses import FileResponse
 from starlette.background import BackgroundTask
@@ -14,13 +19,65 @@ from indextts.infer_v2 import IndexTTS2
 
 app = FastAPI(title="IndexTTS2 API")
 
-# 在进程启动时加载模型；按需调整 fp16 / device / cfg_path 等参数
-tts = IndexTTS2(
-    cfg_path="checkpoints/config.yaml",
-    model_dir="checkpoints",
-    use_fp16=False,
-    device=None,
-)
+
+def _resolve_devices() -> List[Optional[str]]:
+    """Return a list of devices that should host TTS models."""
+
+    if torch.cuda.is_available():
+        device_count = torch.cuda.device_count()
+        if device_count >= 2:
+            return [f"cuda:{i}" for i in range(2)]
+        return ["cuda:0"]
+    return [None]
+
+
+def _init_tts_instances() -> List[IndexTTS2]:
+    devices = _resolve_devices()
+    instances: List[IndexTTS2] = []
+
+    for device in devices:
+        instances.append(
+            IndexTTS2(
+                cfg_path="checkpoints/config.yaml",
+                model_dir="checkpoints",
+                use_fp16=False,
+                device=device,
+            )
+        )
+
+    if len(instances) > 1:
+        print(
+            ">> Multi-GPU inference enabled on devices:",
+            ", ".join(device or "auto" for device in devices),
+        )
+    else:
+        print(
+            ">> Single model instance initialised on device:",
+            devices[0] or "auto",
+        )
+
+    return instances
+
+
+_tts_instances = _init_tts_instances()
+_tts_queue = deque(_tts_instances)
+_tts_lock = asyncio.Lock()
+_tts_semaphore = asyncio.Semaphore(len(_tts_instances))
+
+
+@asynccontextmanager
+async def _acquire_tts() -> IndexTTS2:
+    await _tts_semaphore.acquire()
+    instance: IndexTTS2 | None = None
+    try:
+        async with _tts_lock:
+            instance = _tts_queue.popleft()
+        yield instance
+    finally:
+        if instance is not None:
+            async with _tts_lock:
+                _tts_queue.append(instance)
+        _tts_semaphore.release()
 
 def _save_upload(upload: UploadFile, target: Path) -> str:
     with target.open("wb") as f:
@@ -59,24 +116,26 @@ async def synthesize(
 
         output_path = tmpdir / "output.wav"
 
-        tts.infer(
-            spk_audio_prompt=str(prompt_path),
-            text=text,
-            output_path=str(output_path),
-            emo_audio_prompt=str(emo_path) if emo_path else None,
-            emo_alpha=emo_alpha,
-            emo_vector=emo_vector,
-            use_emo_text=use_emo_text,
-            emo_text=emo_text,
-            use_random=use_random,
-            interval_silence=interval_silence,
-            max_text_tokens_per_segment=max_text_tokens_per_segment,
-            temperature=temperature,
-            top_p=top_p,
-            top_k=top_k,
-            repetition_penalty=repetition_penalty,
-            max_mel_tokens=max_mel_tokens,
-        )
+        async with _acquire_tts() as tts_instance:
+            await asyncio.to_thread(
+                tts_instance.infer,
+                spk_audio_prompt=str(prompt_path),
+                text=text,
+                output_path=str(output_path),
+                emo_audio_prompt=str(emo_path) if emo_path else None,
+                emo_alpha=emo_alpha,
+                emo_vector=emo_vector,
+                use_emo_text=use_emo_text,
+                emo_text=emo_text,
+                use_random=use_random,
+                interval_silence=interval_silence,
+                max_text_tokens_per_segment=max_text_tokens_per_segment,
+                temperature=temperature,
+                top_p=top_p,
+                top_k=top_k,
+                repetition_penalty=repetition_penalty,
+                max_mel_tokens=max_mel_tokens,
+            )
 
         return FileResponse(
             output_path,


### PR DESCRIPTION
## Summary
- initialize a pool of IndexTTS2 instances across available GPUs (up to two)
- add an asynchronous resource manager to dispatch API requests to free GPU workers
- run blocking inference in a worker thread so the FastAPI event loop stays responsive

## Testing
- python -m compileall api_server.py

------
https://chatgpt.com/codex/tasks/task_b_68d6494dbf50832690d699d034bb803b